### PR TITLE
Fix: 프로필 설정 403에러 로직 추가(main)

### DIFF
--- a/src/apis/instance/axiosInstance.ts
+++ b/src/apis/instance/axiosInstance.ts
@@ -1,4 +1,5 @@
 import { useAuthStore } from '@/src/store/authStore'
+import { useProfileSetupStore } from '@/src/store/profileSetupStore'
 import axios from 'axios'
 import { requestPostReissue } from '../request/requestPostReissue'
 
@@ -43,6 +44,14 @@ axiosInstance.interceptors.response.use(
   (response) => response,
   async (error) => {
     const originalRequest = error.config
+
+    if (
+      error.response?.status === 403 &&
+      error.response?.data?.code === 'USR007'
+    ) {
+      useProfileSetupStore.getState().open()
+      return Promise.reject(error)
+    }
 
     if (error.response?.status === 401 && !originalRequest._retry) {
       originalRequest._retry = true

--- a/src/app/(auth)/explore/page.tsx
+++ b/src/app/(auth)/explore/page.tsx
@@ -9,7 +9,6 @@ import { useDebounce } from '@/src/hooks/useDebounce'
 import { useState } from 'react'
 import { SearchLinksInput } from '../_components/SearchLinksInput/SearchLinksInput'
 import { OtherUserLinksContainer } from './_components/OtherUserLinksContainer/OtherUserLinksContainer'
-import { ProfileSetup } from './_components/ProfileSetup/ProfileSetup'
 
 export default function ExplorePage() {
   const [selectedTab, setSelectedTab] = useState<Tab>(ALL_TAB)
@@ -79,8 +78,6 @@ export default function ExplorePage() {
             : isOtherUserLinkListLoading
         }
       />
-
-      <ProfileSetup />
     </main>
   )
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import localFont from 'next/font/local'
 import './globals.css'
 
+import { ProfileSetup } from './(auth)/explore/_components/ProfileSetup/ProfileSetup'
 import { Providers } from './providers'
 
 const pretendard = localFont({
@@ -34,7 +35,10 @@ export default function RootLayout({
   return (
     <html lang="ko" className={pretendard.variable}>
       <body>
-        <Providers>{children}</Providers>
+        <Providers>
+          {children}
+          <ProfileSetup />
+        </Providers>
       </body>
     </html>
   )

--- a/src/components/Modal/ProfileModal.tsx
+++ b/src/components/Modal/ProfileModal.tsx
@@ -1,4 +1,3 @@
-// ProfileModal.tsx
 import Image from 'next/image'
 import { ChangeEvent, useRef, useState } from 'react'
 import { useForm, useWatch } from 'react-hook-form'
@@ -6,14 +5,16 @@ import { Button } from '../Button'
 import { Modal } from './Modal'
 import { ProfileField } from './ProfileField'
 
+export interface ProfileFormData {
+  profile: { nickname: string; introduction: string }
+  profileImage?: File | null
+  backgroundImage?: File | null
+}
+
 interface ProfileModalProps {
   isModalOpen: boolean
   setModalOpen: (isModalOpen: boolean) => void
-  onSubmit: (data: {
-    profile: { nickname: string; introduction: string }
-    profileImage?: File | null
-    backgroundImage?: File | null
-  }) => void
+  onSubmit: (data: ProfileFormData) => void
   initialData?: {
     nickname: string
     introduction: string

--- a/src/store/profileSetupStore.ts
+++ b/src/store/profileSetupStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand'
+
+interface ProfileSetupStore {
+  isOpen: boolean
+  open: () => void
+  close: () => void
+}
+
+export const useProfileSetupStore = create<ProfileSetupStore>((set) => ({
+  isOpen: false,
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+}))


### PR DESCRIPTION
<!-- PR 제목은 "✨ Feat(#100): 이런저런 내용" 형식으로 작성 -->

## #️⃣ 이슈

- close #이슈번호 <!-- 이슈 번호 입력 -->

## 📝 작업 내용

* 프로필 설정 안하고 화면 나갔을 때, 403에러가 뜨면 프로필 설정하는 모달이 뜰수있도록 수정

## 📸 결과물

<!-- 결과물에 대한 스크린샷을 작성해주세요. -->

## ✅ 체크 리스트

- [ ] Todo
- [ ] Todo

## 👩‍💻 공유 포인트 및 논의 사항

<!-- 공유하거나 논의할 사항을 작성해주세요. -->
- 로컬에서 카카오로그인 관련 기능 테스트 불가하여 관련 코드들은 테스트를 위해 메인에 머지 예정