### PR TITLE
Feat: 탐색 추천 링크 커서 기반 무한스크롤 적용

### DIFF
--- a/src/apis/query/recommendation/useGetOtherUserLinkList.ts
+++ b/src/apis/query/recommendation/useGetOtherUserLinkList.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query'
+import { useInfiniteQuery } from '@tanstack/react-query'
 import {
   requestGetOtherUserLinkList,
   RequestGetOtherUserLinkListParams,
@@ -6,10 +6,16 @@ import {
 import { recommendationKeys } from './recommendationKeys'
 
 export const useGetOtherUserLinkList = (
-  params: RequestGetOtherUserLinkListParams,
+  params: Omit<RequestGetOtherUserLinkListParams, 'cursor'>,
 ) => {
-  return useQuery({
+  return useInfiniteQuery({
     queryKey: recommendationKeys.otherUserLinkList(params),
-    queryFn: () => requestGetOtherUserLinkList(params),
+    queryFn: ({ pageParam }) =>
+      requestGetOtherUserLinkList({ ...params, cursor: pageParam }),
+    initialPageParam: null as string | number | null,
+    getNextPageParam: (lastPage) => {
+      const { hasNext, nextCursor } = lastPage.data
+      return hasNext ? nextCursor : undefined
+    },
   })
 }

--- a/src/apis/request/requestGetOtherUserLinkList.ts
+++ b/src/apis/request/requestGetOtherUserLinkList.ts
@@ -3,23 +3,37 @@ import { axiosInstance } from '../instance/axiosInstance'
 import { OtherUserLinkItem } from '@/src/types/recommendations/recommendations'
 
 export interface RequestGetOtherUserLinkListParams {
-  category?: string
+  category?: string | null
+  cursor?: string | number | null
   size?: number
 }
 
-export type RequestGetOtherUserLinkListResponse = BaseResponse<
-  OtherUserLinkItem[]
->
+export type RequestGetOtherUserLinkListResponse = BaseResponse<{
+  contents: OtherUserLinkItem[]
+  nextCursor: string | number | null
+  hasNext: boolean
+}>
 
 export const requestGetOtherUserLinkList = async ({
   category,
-  size,
+  cursor,
+  size = 20,
 }: RequestGetOtherUserLinkListParams): Promise<RequestGetOtherUserLinkListResponse> => {
+  const params: Record<string, string | number> = {
+    size,
+  }
+
+  if (cursor !== undefined && cursor !== null) {
+    params.cursor = cursor
+  }
+
+  // category가 존재하고 '전체'가 아닌 경우에만 파라미터에 추가
+  if (category && category !== '전체') {
+    params.category = category
+  }
+
   const res = await axiosInstance.get('/recommendations', {
-    params: {
-      category,
-      size,
-    },
+    params,
   })
 
   return res.data

--- a/src/apis/request/requestGetSearchOtherUserLinks.ts
+++ b/src/apis/request/requestGetSearchOtherUserLinks.ts
@@ -11,11 +11,15 @@ export type RequestGetSearchOtherUserLinksResponse = BaseResponse<
   OtherUserLinkItem[]
 >
 
-export const requestGetSearchOtherUserLinks = async (
-  params: RequestGetSearchOtherUserLinksParams,
-): Promise<RequestGetSearchOtherUserLinksResponse> => {
+export const requestGetSearchOtherUserLinks = async ({
+  keyword,
+  size = 10,
+}: RequestGetSearchOtherUserLinksParams): Promise<RequestGetSearchOtherUserLinksResponse> => {
   const res = await axiosInstance.get('/recommendations/search', {
-    params,
+    params: {
+      keyword,
+      size,
+    },
   })
 
   return res.data

--- a/src/app/(auth)/explore/_components/OtherUserLinksContainer/OtherUserLinksContainer.tsx
+++ b/src/app/(auth)/explore/_components/OtherUserLinksContainer/OtherUserLinksContainer.tsx
@@ -3,34 +3,69 @@
 import { OtherLinkCard } from '@/src/components/LinkCard'
 import { OtherUserLinkItem } from '@/src/types/recommendations/recommendations'
 import { SaveOtherUserLinkModal } from '../SaveOtherUserLinkModal/SaveOtherUserLinkModal'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { EmptyLinks } from '@/src/components/EmptyLinks/EmptyLinks'
 
 interface OtherUserLinksContainerProps {
   otherUserLinkList: OtherUserLinkItem[]
   isLoading: boolean
+  onLoadMore?: () => void
+  hasMore?: boolean
+  isFetchingNextPage?: boolean
 }
 
 export function OtherUserLinksContainer({
   otherUserLinkList,
   isLoading,
+  onLoadMore,
+  hasMore,
+  isFetchingNextPage,
 }: OtherUserLinksContainerProps) {
   const [selectedLink, setSelectedLink] = useState<OtherUserLinkItem | null>(
     null,
   )
+  const observerRef = useRef<HTMLDivElement>(null)
 
-  return isLoading ? (
+  useEffect(() => {
+    if (!hasMore || isFetchingNextPage || isLoading) return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          onLoadMore?.()
+        }
+      },
+      { threshold: 0.1 },
+    )
+
+    const currentObserverTarget = observerRef.current
+    if (currentObserverTarget) {
+      observer.observe(currentObserverTarget)
+    }
+
+    return () => {
+      if (currentObserverTarget) {
+        observer.unobserve(currentObserverTarget)
+      }
+    }
+  }, [hasMore, onLoadMore, isFetchingNextPage, isLoading])
+
+  return isLoading && !otherUserLinkList.length ? (
     <div className="text-center">Loading...</div>
   ) : otherUserLinkList.length ? (
-    <div className="relative min-h-0">
+    <div className="relative h-full min-h-0">
       <div className="scrollbar-hide h-full overflow-y-auto pb-24">
         <ul className="flex flex-wrap gap-10">
-          {otherUserLinkList?.map((item: OtherUserLinkItem) => (
-            <li key={item.id} onClick={() => setSelectedLink(item)}>
+          {otherUserLinkList?.map((item: OtherUserLinkItem, index: number) => (
+            <li
+              key={`${item.id}-${index}`}
+              onClick={() => setSelectedLink(item)}
+            >
               <OtherLinkCard data={item} />
             </li>
           ))}
         </ul>
+        {hasMore && <div ref={observerRef} className="h-20 w-full" />}
       </div>
 
       {selectedLink && (

--- a/src/components/LinkCard/OtherLinkCard.tsx
+++ b/src/components/LinkCard/OtherLinkCard.tsx
@@ -21,8 +21,8 @@ export function OtherLinkCard({ data }: OtherLinkCardProps) {
       }
       footer={
         <OtherLinkCardFooter
-          nickname={data.user.nickname}
-          profileImageUrl={data.user.profileImageUrl}
+          nickname={data?.user?.nickname ?? ''}
+          profileImageUrl={data?.user?.profileImageUrl ?? ''}
         />
       }
     />


### PR DESCRIPTION
## #️⃣ 이슈

- close #85

## 📝 작업 내용

탐색 페이지 추천 링크를 한 번에 다 불러오는 방식에서,  
스크롤을 내릴 때마다 다음 데이터를 가져오는 방식으로 바꿨습니다.

- 추천 링크 조회를 무한스크롤 구조로 변경
- API 응답을 페이지 단위(`contents`, `nextCursor`, `hasNext`)로 처리
- 스크롤 하단 도달 시 다음 페이지 자동 호출
- 검색 결과는 기존처럼 별도 조회로 유지
- `전체` 카테고리는 요청 파라미터에서 제외되도록 정리
- 사용자 정보가 없을 때 에러 나지 않게 안전 처리

## 📸 결과물

- 탐색 페이지에서 아래로 내리면 추천 링크가 계속 이어서 로드됩니다.
- 검색했을 때는 검색 결과만 보여주고, 무한스크롤은 일반 추천 목록에서만 동작합니다.

## ✅ 체크 리스트

- [x] 추천 목록 무한스크롤 적용
- [x] 커서 기반 페이지네이션 반영
- [x] 스크롤 하단 감지 후 추가 조회 연결
- [x] 검색/일반 목록 분기 처리
- [ ] QA (카테고리 변경, 마지막 페이지, 검색 후 복귀)

## 🙋 공유 포인트 및 논의 사항

- `전체` 카테고리 처리 방식은 백엔드 규칙과 한번 더 맞춰보면 좋습니다.

