### PR TITLE
Fix : 모바일/좁은 화면에서 마이페이지 겹침 및 스크롤 이슈 수정

### DIFF
--- a/src/app/(auth)/_components/LinkListContainer/LinkListContainer.tsx
+++ b/src/app/(auth)/_components/LinkListContainer/LinkListContainer.tsx
@@ -33,7 +33,6 @@ export function LinkListContainer({
   const [isMoveLinkModalOpen, setMoveLinkModalOpen] = useState(false)
 
   const openDrawer = useDrawerStore((state) => state.open)
-  const initializeValues = useDrawerStore((state) => state.initializeValues)
 
   const { mutateAsync: deleteLink } = useDeleteLinkMutation()
   const { data: linkDetailsData, isLoading: isLinkDetailsLoading } =
@@ -114,7 +113,11 @@ export function LinkListContainer({
       )}
       <div className="flex flex-wrap gap-10">
         {linkList.map((item: LinkItem | SearchLinkItem) => (
-          <div key={item.id} onClick={() => handleOpenLinkDetail(item.id)}>
+          <div
+            key={item.id}
+            onClick={() => handleOpenLinkDetail(item.id)}
+            className="w-full sm:w-auto"
+          >
             <MyLinkCard data={item} onDelete={handleDelete} />
           </div>
         ))}

--- a/src/app/(auth)/explore/_components/OtherUserLinksContainer/OtherUserLinksContainer.tsx
+++ b/src/app/(auth)/explore/_components/OtherUserLinksContainer/OtherUserLinksContainer.tsx
@@ -60,6 +60,7 @@ export function OtherUserLinksContainer({
             <li
               key={`${item.id}-${index}`}
               onClick={() => setSelectedLink(item)}
+              className="w-full sm:w-auto"
             >
               <OtherLinkCard data={item} />
             </li>

--- a/src/app/(auth)/explore/layout.tsx
+++ b/src/app/(auth)/explore/layout.tsx
@@ -5,5 +5,5 @@ export default function ExploreLayout({
 }: {
   children: React.ReactNode
 }) {
-  return <div className="flex h-full flex-col pt-36">{children}</div>
+  return <div className="flex h-full flex-col pt-16 md:pt-36">{children}</div>
 }

--- a/src/app/(auth)/explore/page.tsx
+++ b/src/app/(auth)/explore/page.tsx
@@ -86,7 +86,7 @@ export default function ExplorePage() {
   }
 
   return (
-    <main className="flex h-full flex-col overflow-y-hidden px-84">
+    <main className="flex h-full flex-col overflow-y-hidden px-16 md:px-84">
       <div className="shrink-0">
         <SearchLinksInput
           value={searchKeyword}
@@ -98,7 +98,7 @@ export default function ExplorePage() {
           tabs={tabs}
           selectedTab={selectedTab}
           onChange={handleTabChange}
-          className="py-30"
+          className="py-20 md:py-30"
         />
       </div>
 

--- a/src/app/(auth)/home/_components/SaveLinkInput/SaveLinkInput.tsx
+++ b/src/app/(auth)/home/_components/SaveLinkInput/SaveLinkInput.tsx
@@ -18,7 +18,7 @@ export function SaveLinkInput() {
     <div className="relative">
       <Input
         className="rounded-20 text-body-1 px-40"
-        height="h-100"
+        height="h-84 md:h-100"
         placeholder="다시 쓰고 싶은 링크를 넣어 보세요"
         value={url}
         onChange={(e) => setUrl(e.target.value)}
@@ -27,9 +27,9 @@ export function SaveLinkInput() {
       <Image
         src="/icons/share.svg"
         alt="share"
-        width={40}
-        height={40}
-        className="absolute top-1/2 right-40 -translate-y-1/2 cursor-pointer"
+        width={32}
+        height={32}
+        className="absolute top-1/2 right-20 -translate-y-1/2 cursor-pointer md:right-40"
         onClick={() => openSaveLinkModal(url)}
       />
     </div>

--- a/src/app/(auth)/home/layout.tsx
+++ b/src/app/(auth)/home/layout.tsx
@@ -5,5 +5,5 @@ export default function HomeLayout({
 }: {
   children: React.ReactNode
 }) {
-  return <div className="h-full pt-84 pb-24">{children}</div>
+  return <div className="h-full pt-24 pb-16 md:pt-84 md:pb-24">{children}</div>
 }

--- a/src/app/(auth)/home/page.tsx
+++ b/src/app/(auth)/home/page.tsx
@@ -68,8 +68,8 @@ export default function Home() {
   }
 
   return (
-    <div className="scrollbar-hide h-full overflow-y-auto px-84">
-      <h1 className="text-display-2 text-gray-default pb-38">
+    <div className="scrollbar-hide h-full overflow-y-auto px-16 md:px-84">
+      <h1 className="text-heading-1 text-gray-default md:text-display-2 pb-28 md:pb-38">
         Save Links.
         <br />
         Use them again.
@@ -77,7 +77,7 @@ export default function Home() {
 
       <SaveLinkInput />
 
-      <div className="sticky top-0 z-10 mt-25 bg-white">
+      <div className="sticky top-0 z-10 mt-20 bg-white md:mt-25">
         <SearchLinksInput
           value={searchKeyword}
           placeholder="왜 저장했는지로 검색해 보세요"

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -3,7 +3,9 @@
 import { SaveLinkModal } from '@/src/components/Modal'
 import { OpenSaveLinkButton } from '@/src/components/OpenSaveLinkButton/OpenSaveLinkButton'
 import { Sidebar } from '@/src/components/Sidebar'
+import Image from 'next/image'
 import { usePathname } from 'next/navigation'
+import { useState } from 'react'
 
 export default function AuthLayout({
   children,
@@ -12,18 +14,58 @@ export default function AuthLayout({
 }) {
   const pathname = usePathname()
   const isMyPage = pathname === '/mypage'
+  const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false)
 
   return (
-    <div className="bg-blue-light flex h-screen">
-      <Sidebar />
+    <div className="bg-blue-light flex h-dvh min-h-screen overflow-hidden">
+      <div className="hidden h-full md:block">
+        <Sidebar />
+      </div>
 
-      <main className="relative flex min-w-0 flex-1 pt-24">
-        <div className="rounded-tl-20 flex min-w-0 flex-1 flex-col bg-white">
-          {children}
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+        <header className="bg-blue-light flex items-center justify-between px-16 py-12 md:hidden">
+          <Image
+            src="/images/logo-keepit.png"
+            alt="keepit"
+            width={96}
+            height={38}
+            priority
+          />
+          <button
+            type="button"
+            onClick={() => setIsMobileSidebarOpen(true)}
+            className="text-body-3 text-gray-default rounded-10 bg-white px-14 py-8"
+          >
+            메뉴
+          </button>
+        </header>
+
+        <main className="relative flex min-h-0 min-w-0 flex-1 pt-0 md:pt-24">
+          <div className="md:rounded-tl-20 flex min-h-0 min-w-0 flex-1 flex-col rounded-none bg-white">
+            {children}
+          </div>
+          {!isMyPage && <OpenSaveLinkButton />}
+          <SaveLinkModal />
+        </main>
+      </div>
+
+      {isMobileSidebarOpen && (
+        <div className="fixed inset-0 z-[60] md:hidden">
+          <button
+            type="button"
+            aria-label="메뉴 닫기"
+            className="absolute inset-0 bg-black/25"
+            onClick={() => setIsMobileSidebarOpen(false)}
+          />
+
+          <div className="relative h-full w-[240px] max-w-[85vw] shadow-xl">
+            <Sidebar
+              forceExpanded={true}
+              onNavigate={() => setIsMobileSidebarOpen(false)}
+            />
+          </div>
         </div>
-        {!isMyPage && <OpenSaveLinkButton />}
-        <SaveLinkModal />
-      </main>
+      )}
     </div>
   )
 }

--- a/src/app/(auth)/mypage/page.tsx
+++ b/src/app/(auth)/mypage/page.tsx
@@ -33,9 +33,9 @@ export default function MyPage() {
 
   if (isLoading) {
     return (
-      <div className="h-full bg-gray-50 p-24">
+      <div className="h-full bg-gray-50 p-16 md:p-24">
         <div className="mx-auto max-w-6xl">
-          <div className="grid grid-cols-3 gap-24">
+          <div className="grid grid-cols-1 gap-24 md:grid-cols-3">
             {[1, 2, 3].map((i) => (
               <div
                 key={i}
@@ -80,10 +80,10 @@ export default function MyPage() {
   const { topReferences, readState, savePattern } = userStats.data
 
   return (
-    <div className="h-full overflow-x-hidden overflow-y-auto">
-      <div className="flex min-h-full flex-col">
+    <div className="h-full min-h-0 flex-1 overflow-x-hidden overflow-y-auto">
+      <div className="mx-auto flex min-h-full w-full max-w-[1280px] flex-col">
         {/* 배경 이미지 섹션 */}
-        <div className="relative h-[200px] w-full shrink-0 px-29 pt-29">
+        <div className="relative h-[180px] w-full shrink-0 px-16 pt-16 md:h-[200px] md:px-29 md:pt-29">
           <div className="rounded-20 relative h-full w-full overflow-hidden">
             <Image
               src={
@@ -98,8 +98,8 @@ export default function MyPage() {
         </div>
 
         {/* 프로필 및 통계 카드 섹션 */}
-        <div className="px-24">
-          <div className="relative -mt-50 mb-32 ml-50">
+        <div className="px-16 md:px-24">
+          <div className="relative -mt-42 mb-32 ml-0 md:-mt-50 md:ml-50">
             <div className="relative mb-18 w-fit">
               <div className="relative h-75 w-75 overflow-hidden rounded-full border-4 border-white bg-white">
                 <Image
@@ -123,8 +123,8 @@ export default function MyPage() {
               </button>
             </div>
 
-            <div className="mb-10 flex items-center gap-12">
-              <h1 className="text-heading-3 text-gray-default">
+            <div className="mb-10 flex min-w-0 items-center gap-12">
+              <h1 className="text-heading-3 text-gray-default truncate">
                 {userInfo.data.nickname}
               </h1>
               <button
@@ -140,7 +140,7 @@ export default function MyPage() {
               </button>
             </div>
 
-            <p className="text-body-2 text-gray-default mb-32">
+            <p className="text-body-2 text-gray-default mb-32 break-words">
               {userInfo.data.introduction || '반갑습니다'}
             </p>
 

--- a/src/app/(auth)/reference/ReferenceFolderItem/ReferenceFolderItem.tsx
+++ b/src/app/(auth)/reference/ReferenceFolderItem/ReferenceFolderItem.tsx
@@ -81,7 +81,7 @@ export default function ReferenceFolderItem({
     <>
       <div
         onClick={handleFolderClick}
-        className="group rounded-10 relative flex h-[107px] min-w-[148px] cursor-pointer flex-col border border-[#EBEBEB] bg-white px-15 pt-16 pb-14 shadow-[0px_0px_5px_0px_#EAEAEA]"
+        className="group rounded-10 relative flex h-[107px] w-full min-w-0 cursor-pointer flex-col border border-[#EBEBEB] bg-white px-15 pt-16 pb-14 shadow-[0px_0px_5px_0px_#EAEAEA]"
       >
         <div className="flex items-start justify-between">
           <div className="relative h-28 w-36">

--- a/src/app/(auth)/reference/ReferenceFolderList/ReferenceFolderList.tsx
+++ b/src/app/(auth)/reference/ReferenceFolderList/ReferenceFolderList.tsx
@@ -9,7 +9,7 @@ export default function ReferenceFolderList({
   data: ReferenceItem[]
 }) {
   return (
-    <div className="grid w-full grid-cols-6 gap-x-29 gap-y-20 py-20">
+    <div className="grid w-full grid-cols-1 gap-x-29 gap-y-20 py-20 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6">
       {data.map((item) => (
         <ReferenceFolderItem key={item.id} item={item} />
       ))}

--- a/src/app/(auth)/reference/[id]/page.tsx
+++ b/src/app/(auth)/reference/[id]/page.tsx
@@ -148,7 +148,7 @@ export default function ReferenceDetails({
   }
 
   return (
-    <div className="scrollbar-hide h-full overflow-y-auto px-84">
+    <div className="scrollbar-hide h-full overflow-y-auto px-16 md:px-84">
       <div className="sticky top-0 z-10 mt-25 bg-white">
         {isAllTab && (
           <div className="flex flex-col">
@@ -175,7 +175,7 @@ export default function ReferenceDetails({
         {!isAllTab && (
           <>
             <div className="flex flex-col gap-24 pt-35 pb-32">
-              <div className="flex items-center justify-between">
+              <div className="flex flex-col gap-12 sm:flex-row sm:items-center sm:justify-between">
                 <div className="flex items-center gap-12">
                   <h1 className="text-heading-3 text-gray-default">
                     {folderDetail?.title}
@@ -225,7 +225,7 @@ export default function ReferenceDetails({
         )}
       </div>
 
-      <div className="mt-44">
+      <div className="mt-28 md:mt-44">
         <LinkListContainer
           linkList={linkList}
           isLoading={isLoading}

--- a/src/app/(auth)/reference/page.tsx
+++ b/src/app/(auth)/reference/page.tsx
@@ -65,9 +65,9 @@ export default function Reference() {
   }
 
   return (
-    <div className="scrollbar-hide h-full overflow-y-auto px-84">
+    <div className="scrollbar-hide h-full overflow-y-auto px-16 md:px-84">
       <div className="sticky top-0 z-10 mt-25 bg-white">
-        <div className="flex items-end justify-between pb-16">
+        <div className="flex flex-col gap-12 pb-16 sm:flex-row sm:items-end sm:justify-between">
           <Tabs
             defaultTap={REFERENCE_TABS[0]}
             tabs={REFERENCE_TABS.slice(1)}
@@ -78,7 +78,7 @@ export default function Reference() {
 
           <Button
             onClick={handleCreateReferenceView}
-            width="w-172"
+            width="w-full sm:w-172"
             height="h-42"
           >
             레퍼런스 뷰 생성
@@ -98,11 +98,11 @@ export default function Reference() {
 
       {showGuestDefaultFolder ? (
         <div className="py-20">
-          <div className="grid w-full grid-cols-6 gap-x-29 gap-y-20">
+          <div className="grid w-full grid-cols-1 gap-x-29 gap-y-20 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6">
             <button
               type="button"
               onClick={() => setIsLoginModalOpen(true)}
-              className="rounded-10 relative flex h-[107px] min-w-[148px] cursor-pointer flex-col border border-[#EBEBEB] bg-white px-15 pt-16 pb-14 text-left shadow-[0px_0px_5px_0px_#EAEAEA]"
+              className="rounded-10 relative flex h-[107px] w-full min-w-0 cursor-pointer flex-col border border-[#EBEBEB] bg-white px-15 pt-16 pb-14 text-left shadow-[0px_0px_5px_0px_#EAEAEA]"
             >
               <div className="relative h-28 w-36">
                 <Image

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import localFont from 'next/font/local'
+import type { Viewport } from 'next'
 import './globals.css'
 
 import { UserInitializer } from './(auth)/_components/UserInitializer/UserInitializer'
@@ -27,6 +28,11 @@ const pretendard = localFont({
   variable: '--font-pretendard',
   display: 'swap',
 })
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+}
 
 export default function RootLayout({
   children,

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -84,7 +84,7 @@ export function Drawer({
 
   return isOpen ? (
     <div
-      className={`fixed top-0 right-0 z-50 flex h-screen w-[405px] flex-col overflow-hidden bg-white p-30 shadow-xl ${
+      className={`fixed top-0 right-0 z-50 flex h-dvh w-full max-w-[405px] flex-col overflow-hidden bg-white p-20 shadow-xl md:p-30 ${
         isClosing ? 'animate-drawer-out' : 'animate-drawer-in'
       }`}
     >

--- a/src/components/LinkCard/LinkCardLayout.tsx
+++ b/src/components/LinkCard/LinkCardLayout.tsx
@@ -22,10 +22,10 @@ export function LinkCardLayout({
   }
 
   return (
-    <div className="bg-gray-box mb-12 flex h-[286px] w-[331px] flex-col rounded-[10px] px-8 pt-8 pb-[10px] opacity-100">
+    <div className="bg-gray-box mb-12 flex h-[286px] w-full max-w-[331px] flex-col rounded-[10px] px-8 pt-8 pb-[10px] opacity-100 sm:w-[331px]">
       {header}
 
-      <div className="mb-16 max-w-[273px] px-12">
+      <div className="mb-16 max-w-full px-12 sm:max-w-[273px]">
         <div className="text-body-1 min-h-[72px] text-[#2D2D2D]">
           <div className="line-clamp-3 [display:-webkit-box] overflow-hidden text-justify break-all [-webkit-box-orient:vertical] [-webkit-line-clamp:3]">
             <span>{title}</span>

--- a/src/components/OpenSaveLinkButton/OpenSaveLinkButton.tsx
+++ b/src/components/OpenSaveLinkButton/OpenSaveLinkButton.tsx
@@ -8,7 +8,7 @@ export function OpenSaveLinkButton() {
 
   return (
     <button
-      className="absolute right-40 bottom-40 cursor-pointer"
+      className="absolute right-16 bottom-20 cursor-pointer md:right-40 md:bottom-40"
       onClick={() => openSaveLinkModal()}
     >
       <Image

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -16,14 +16,19 @@ const navItems = [
   { icon: NavMypage, label: '마이페이지', href: '/mypage' },
 ]
 
-export function Sidebar() {
+interface SidebarProps {
+  forceExpanded?: boolean
+  onNavigate?: () => void
+}
+
+export function Sidebar({ forceExpanded, onNavigate }: SidebarProps) {
   const isDrawerOpen = useDrawerStore((state) => state.isOpen)
-  const isExpanded = !isDrawerOpen
+  const isExpanded = forceExpanded ?? !isDrawerOpen
 
   return (
     <aside
       className={cn(
-        'bg-blue-light flex h-screen flex-col pb-[30px]',
+        'bg-blue-light flex h-full min-h-0 flex-col pb-[30px]',
         isExpanded ? 'w-[240px] px-10' : 'w-[62px] items-center px-0',
       )}
     >
@@ -31,14 +36,22 @@ export function Sidebar() {
       <SidebarProfile isExpanded={isExpanded} />
       <nav className="shrink-0 space-y-2">
         {navItems.map((item, index) => (
-          <SidebarNav key={index} {...item} isExpanded={isExpanded} />
+          <SidebarNav
+            key={index}
+            {...item}
+            isExpanded={isExpanded}
+            onNavigate={onNavigate}
+          />
         ))}
       </nav>
       <div className="flex-1" />
       <div className="flex shrink-0 flex-col">
         {isExpanded && <div className="bg-gray-white mx-[10px] h-[1px]" />}
         <div className="max-h-[250px] overflow-hidden">
-          <SidebarReferenceListList isExpanded={isExpanded} />
+          <SidebarReferenceListList
+            isExpanded={isExpanded}
+            onNavigate={onNavigate}
+          />
         </div>
         <div className="mt-[20px]">
           <SidebarFooter isExpanded={isExpanded} />

--- a/src/components/Sidebar/SidebarNav.tsx
+++ b/src/components/Sidebar/SidebarNav.tsx
@@ -10,6 +10,7 @@ interface SidebarNavProps {
   label: string
   href: string
   isExpanded: boolean
+  onNavigate?: () => void
 }
 
 export default function SidebarNav({
@@ -17,6 +18,7 @@ export default function SidebarNav({
   label,
   href,
   isExpanded,
+  onNavigate,
 }: SidebarNavProps) {
   const pathname = usePathname()
   const isActive = pathname === href
@@ -24,6 +26,7 @@ export default function SidebarNav({
   return (
     <Link
       href={href}
+      onClick={onNavigate}
       className={cn(
         'group flex items-center transition-all',
         isExpanded

--- a/src/components/Sidebar/SidebarReferenceList.tsx
+++ b/src/components/Sidebar/SidebarReferenceList.tsx
@@ -8,10 +8,12 @@ import { useRouter } from 'next/navigation'
 
 interface SidebarReferenceListProps {
   isExpanded: boolean
+  onNavigate?: () => void
 }
 
 export default function SidebarReferenceList({
   isExpanded,
+  onNavigate,
 }: SidebarReferenceListProps) {
   const { isLoggedIn } = useAuthStore()
   const router = useRouter()
@@ -28,6 +30,7 @@ export default function SidebarReferenceList({
 
   const handleReferenceClick = (id: number) => {
     router.push(`/reference/${id}`)
+    onNavigate?.()
   }
 
   if (!isExpanded) return null


### PR DESCRIPTION
## #️⃣ 이슈

- close #87

## 📝 작업 내용

- auth 레이아웃의 높이 계산 구조를 정리해 내부 페이지에서 스크롤이 정상 동작하도록 수정
- 마이페이지 컨테이너를 `flex-1 + min-h-0 + overflow-y-auto` 기반으로 조정
- 좁은 화면에서 겹침이 발생하던 프로필/카드 영역 오프셋(마진/포지셔닝) 반응형 보정
- 텍스트(`nickname`, `introduction`)가 작은 폭에서 깨지지 않도록 `truncate`, `break-words` 적용
- 홈/탐색 탭의 스크롤 동작도 코드 기준으로 점검 완료

## 📸 결과물

- 모바일 및 좁은 화면에서 마이페이지 카드가 겹치지 않고 아래로 자연스럽게 배치됨
- 마이페이지 세로 스크롤 정상 동작 확인
- 기존 데스크톱 UI 스타일은 유지

## ✅ 체크 리스트

- [x] 마이페이지 좁은 화면 겹침 해소
- [x] 마이페이지 세로 스크롤 복구
- [x] 홈 탭 스크롤 동작 확인
- [x] 탐색 탭 스크롤 동작 확인
- [x] lint 실행 시 신규 에러 없음

## 🙋 공유 포인트 및 논의 사항

- 스크롤 이슈는 개별 페이지보다 상위 auth 레이아웃의 `min-h-0` 누락 영향이 커서, 레이아웃 레벨에서 함께 보정했습니다.
- 현재 lint 경고는 기존 코드에 존재

